### PR TITLE
Add support for "banana 2" model in icon generation and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ Output defaults to `./assets` (timestamped filenames).
 
 SnapAI exposes providers via `--model`:
 
-| Provider                    | SnapAI flag            | Underlying model             | Notes                                                     |
-| --------------------------- | ---------------------- | ---------------------------- | --------------------------------------------------------- |
-| OpenAI (latest)             | `--model gpt-1.5`      | `gpt-image-1.5`              | Always 1:1 square `1024x1024`, background/output controls |
-| OpenAI (previous)           | `--model gpt-1`        | `gpt-image-1`                | Same controls as above                                    |
-| Google Nano Banana (normal) | `--model banana`       | `gemini-2.5-flash-image`     | Always 1 image, square output                             |
-| Google Nano Banana (pro)    | `--model banana --pro` | `gemini-3-pro-image-preview` | Quality tiers via `--quality 1k/2k/4k`, multiple via `-n` |
+| Provider                    | SnapAI flag              | Underlying model                   | Notes                                                     |
+| --------------------------- | ------------------------ | ---------------------------------- | --------------------------------------------------------- |
+| OpenAI (latest)             | `--model gpt-1.5`        | `gpt-image-1.5`                    | Always 1:1 square `1024x1024`, background/output controls |
+| OpenAI (previous)           | `--model gpt-1`          | `gpt-image-1`                      | Same controls as above                                    |
+| Google Nano Banana (normal) | `--model banana`         | `gemini-2.5-flash-image`           | Always 1 image, square output                             |
+| Google Nano Banana 2        | `--model "banana 2"`     | `gemini-3.1-flash-image-preview`   | 1 image, thinking config, 1K output                      |
+| Google Nano Banana (pro)    | `--model banana --pro`   | `gemini-3-pro-image-preview`       | Quality tiers via `--quality 1k/2k/4k`, multiple via `-n` |
 
 > **Tip** 💡  
 > If you want **multiple variations** quickly, use **OpenAI** (`-n`) or **Banana Pro** (`--pro -n ...`).

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ SnapAI exposes providers via `--model`:
 | OpenAI (latest)             | `--model gpt-1.5`        | `gpt-image-1.5`                    | Always 1:1 square `1024x1024`, background/output controls |
 | OpenAI (previous)           | `--model gpt-1`          | `gpt-image-1`                      | Same controls as above                                    |
 | Google Nano Banana (normal) | `--model banana`         | `gemini-2.5-flash-image`           | Always 1 image, square output                             |
-| Google Nano Banana 2        | `--model "banana 2"`     | `gemini-3.1-flash-image-preview`   | 1 image, thinking config, 1K output                      |
+| Google Nano Banana 2        | `--model banana-2`       | `gemini-3.1-flash-image-preview`   | 1 image, thinking config, 1K output                      |
 | Google Nano Banana (pro)    | `--model banana --pro`   | `gemini-3-pro-image-preview`       | Quality tiers via `--quality 1k/2k/4k`, multiple via `-n` |
 
 > **Tip** 💡  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapai",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "AI-powered icon generation CLI for mobile app developers",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "tsc --watch",
     "dev:cmd": "./dev-cli.js",
     "test": "jest",
+    "test:icon-batch": "bash scripts/test-icon-batch.sh",
     "lint": "eslint src/**/*.ts",
     "clean": "rm -rf dist bundle"
   },

--- a/src/commands/icon.ts
+++ b/src/commands/icon.ts
@@ -35,7 +35,7 @@ function isStyleDangerous(style?: string): boolean {
 
 export default class IconCommand extends Command {
   static description =
-    "Generate AI-powered app icons using OpenAI (gpt-1.5/gpt-1) or Gemini (banana / banana 2)";
+    "Generate AI-powered app icons using OpenAI (gpt-1.5/gpt-1) or Gemini (banana / banana-2)";
 
   static examples = [
     // Basic usage
@@ -47,8 +47,8 @@ export default class IconCommand extends Command {
     "",
     // Gemini
     '<%= config.bin %> <%= command.id %> --prompt "modern app icon" --model banana',
-    '<%= config.bin %> <%= command.id %> --prompt "app icon" --model "banana 2"',
-    '<%= config.bin %> <%= command.id %> --prompt "app icon" --model "banana 2" --thinking max',
+    '<%= config.bin %> <%= command.id %> --prompt "app icon" --model banana-2',
+    '<%= config.bin %> <%= command.id %> --prompt "app icon" --model banana-2 --thinking max',
     "",
     // Advanced options
     '<%= config.bin %> <%= command.id %> --prompt "logo" --model gpt-1.5 --background transparent --output-format png',
@@ -107,9 +107,9 @@ export default class IconCommand extends Command {
     model: Flags.string({
       char: "m",
       description:
-        'Model: OpenAI ("gpt-1.5" or "gpt-1") or Gemini ("banana" or "banana 2"). (Legacy alias: "gpt")',
+        'Model: OpenAI ("gpt-1.5" or "gpt-1") or Gemini ("banana" or "banana-2"). (Legacy alias: "gpt")',
       default: "gpt-1.5",
-      options: ["gpt-1.5", "gpt-1", "banana", "banana 2", "gpt"],
+      options: ["gpt-1.5", "gpt-1", "banana", "banana-2", "gpt"],
     }),
     quality: Flags.string({
       char: "q",
@@ -193,7 +193,7 @@ export default class IconCommand extends Command {
     }),
     thinking: Flags.string({
       description:
-        'Thinking level for banana 2: minimal (faster, less reasoning) or max (deeper reasoning). Ignored for other models.',
+        'Thinking level for banana-2: minimal (faster, less reasoning) or max (deeper reasoning). Ignored for other models.',
       options: ["minimal", "max"],
     }),
   };
@@ -254,12 +254,12 @@ export default class IconCommand extends Command {
           ? "gpt-1.5"
           : modelFlag;
       const provider: "banana" | "openai" =
-        normalizedModelFlag === "banana" || normalizedModelFlag === "banana 2"
+        normalizedModelFlag === "banana" || normalizedModelFlag === "banana-2"
           ? "banana"
           : "openai";
-      const bananaVariant: "banana" | "banana 2" | undefined =
-        normalizedModelFlag === "banana 2"
-          ? "banana 2"
+      const bananaVariant: "banana" | "banana-2" | undefined =
+        normalizedModelFlag === "banana-2"
+          ? "banana-2"
           : normalizedModelFlag === "banana"
             ? "banana"
             : undefined;
@@ -270,9 +270,9 @@ export default class IconCommand extends Command {
 
       const qualityInput = this.normalizeFlagString(flags.quality, "auto");
 
-      if (flags.thinking && bananaVariant !== "banana 2") {
+      if (flags.thinking && bananaVariant !== "banana-2") {
         this.error(
-          chalk.red('--thinking is only supported with --model "banana 2"')
+          chalk.red('--thinking is only supported with --model banana-2')
         );
       }
 
@@ -322,9 +322,9 @@ export default class IconCommand extends Command {
 
         // Provider-specific validation (so preview matches reality), but do not prompt for confirmation.
         if (provider === "banana") {
-          if (bananaVariant === "banana 2") {
+          if (bananaVariant === "banana-2") {
             if (requestedN !== 1) {
-              this.error(chalk.red("Banana 2 only supports -n 1"));
+              this.error(chalk.red("banana-2 only supports -n 1"));
             }
           } else if (!flags.pro) {
             if (requestedN !== 1) {
@@ -380,8 +380,8 @@ export default class IconCommand extends Command {
         this.log(chalk.gray(`  size: 1024x1024 (fixed)`));
         this.log(chalk.gray(`  n: ${requestedN}`));
         if (provider === "banana") {
-          if (bananaVariant === "banana 2") {
-            this.log(chalk.gray(`  variant: banana 2 (nano banana 2)`));
+          if (bananaVariant === "banana-2") {
+            this.log(chalk.gray(`  variant: banana-2 (nano banana 2)`));
             if (flags.thinking) {
               this.log(chalk.gray(`  thinking: ${flags.thinking}`));
             }
@@ -428,9 +428,9 @@ export default class IconCommand extends Command {
       }
 
       if (provider === "banana") {
-        if (bananaVariant === "banana 2") {
+        if (bananaVariant === "banana-2") {
           if (requestedN !== 1) {
-            this.error(chalk.red("Banana 2 only supports -n 1"));
+            this.error(chalk.red("banana-2 only supports -n 1"));
           }
         } else if (!flags.pro) {
           if (requestedN !== 1) {
@@ -466,13 +466,13 @@ export default class IconCommand extends Command {
       if (provider === "banana") {
         const bananaQuality = this.resolveBananaQuality(qualityInput);
         const thinkingLevel =
-          bananaVariant === "banana 2" && flags.thinking
+          bananaVariant === "banana-2" && flags.thinking
             ? (flags.thinking as "minimal" | "max")
             : undefined;
         const images = await GeminiService.generateBananaImages({
           prompt: finalPrompt,
           pro: flags.pro,
-          n: bananaVariant === "banana 2" ? 1 : flags.pro ? requestedN : 1,
+          n: bananaVariant === "banana-2" ? 1 : flags.pro ? requestedN : 1,
           quality: bananaQuality,
           apiKey: flags["google-api-key"],
           modelVariant: bananaVariant,

--- a/src/commands/icon.ts
+++ b/src/commands/icon.ts
@@ -35,7 +35,7 @@ function isStyleDangerous(style?: string): boolean {
 
 export default class IconCommand extends Command {
   static description =
-    "Generate AI-powered app icons using OpenAI (gpt-1.5/gpt-1) or Gemini (banana)";
+    "Generate AI-powered app icons using OpenAI (gpt-1.5/gpt-1) or Gemini (banana / banana 2)";
 
   static examples = [
     // Basic usage
@@ -47,6 +47,8 @@ export default class IconCommand extends Command {
     "",
     // Gemini
     '<%= config.bin %> <%= command.id %> --prompt "modern app icon" --model banana',
+    '<%= config.bin %> <%= command.id %> --prompt "app icon" --model "banana 2"',
+    '<%= config.bin %> <%= command.id %> --prompt "app icon" --model "banana 2" --thinking max',
     "",
     // Advanced options
     '<%= config.bin %> <%= command.id %> --prompt "logo" --model gpt-1.5 --background transparent --output-format png',
@@ -105,9 +107,9 @@ export default class IconCommand extends Command {
     model: Flags.string({
       char: "m",
       description:
-        'Model: OpenAI ("gpt-1.5" or "gpt-1") or Gemini ("banana"). (Legacy alias: "gpt")',
+        'Model: OpenAI ("gpt-1.5" or "gpt-1") or Gemini ("banana" or "banana 2"). (Legacy alias: "gpt")',
       default: "gpt-1.5",
-      options: ["gpt-1.5", "gpt-1", "banana", "gpt"],
+      options: ["gpt-1.5", "gpt-1", "banana", "banana 2", "gpt"],
     }),
     quality: Flags.string({
       char: "q",
@@ -189,6 +191,11 @@ export default class IconCommand extends Command {
       min: 1,
       max: 10,
     }),
+    thinking: Flags.string({
+      description:
+        'Thinking level for banana 2: minimal (faster, less reasoning) or max (deeper reasoning). Ignored for other models.',
+      options: ["minimal", "max"],
+    }),
   };
 
   private normalizeFlagString(input: unknown, fallback: string): string {
@@ -247,13 +254,27 @@ export default class IconCommand extends Command {
           ? "gpt-1.5"
           : modelFlag;
       const provider: "banana" | "openai" =
-        normalizedModelFlag === "banana" ? "banana" : "openai";
+        normalizedModelFlag === "banana" || normalizedModelFlag === "banana 2"
+          ? "banana"
+          : "openai";
+      const bananaVariant: "banana" | "banana 2" | undefined =
+        normalizedModelFlag === "banana 2"
+          ? "banana 2"
+          : normalizedModelFlag === "banana"
+            ? "banana"
+            : undefined;
       const openaiModel =
         provider === "openai"
           ? (normalizedModelFlag as "gpt-1" | "gpt-1.5" | "gpt")
           : undefined;
 
       const qualityInput = this.normalizeFlagString(flags.quality, "auto");
+
+      if (flags.thinking && bananaVariant !== "banana 2") {
+        this.error(
+          chalk.red('--thinking is only supported with --model "banana 2"')
+        );
+      }
 
       const openaiApiKey = flags["openai-api-key"] || flags["api-key"];
       if (flags["openai-api-key"] && flags["api-key"]) {
@@ -301,7 +322,11 @@ export default class IconCommand extends Command {
 
         // Provider-specific validation (so preview matches reality), but do not prompt for confirmation.
         if (provider === "banana") {
-          if (!flags.pro) {
+          if (bananaVariant === "banana 2") {
+            if (requestedN !== 1) {
+              this.error(chalk.red("Banana 2 only supports -n 1"));
+            }
+          } else if (!flags.pro) {
             if (requestedN !== 1) {
               this.error(chalk.red("Banana normal only supports -n 1"));
             }
@@ -355,13 +380,20 @@ export default class IconCommand extends Command {
         this.log(chalk.gray(`  size: 1024x1024 (fixed)`));
         this.log(chalk.gray(`  n: ${requestedN}`));
         if (provider === "banana") {
-          const bananaQualityResolved = this.resolveBananaQuality(qualityInput);
-          this.log(
-            chalk.gray(
-              `  quality: ${qualityInput} (resolved: ${bananaQualityResolved})`
-            )
-          );
-          this.log(chalk.gray(`  pro: ${flags.pro ? "yes" : "no"}`));
+          if (bananaVariant === "banana 2") {
+            this.log(chalk.gray(`  variant: banana 2 (nano banana 2)`));
+            if (flags.thinking) {
+              this.log(chalk.gray(`  thinking: ${flags.thinking}`));
+            }
+          } else {
+            const bananaQualityResolved = this.resolveBananaQuality(qualityInput);
+            this.log(
+              chalk.gray(
+                `  quality: ${qualityInput} (resolved: ${bananaQualityResolved})`
+              )
+            );
+            this.log(chalk.gray(`  pro: ${flags.pro ? "yes" : "no"}`));
+          }
           if (flags.pro && requestedN >= 5) {
             this.log(
               chalk.yellow(
@@ -395,20 +427,12 @@ export default class IconCommand extends Command {
         return;
       }
 
-      this.log(chalk.blue("🎨 Generating your app icon..."));
-      this.log("");
-      this.log(CTA);
-      this.log("");
-      this.log(chalk.gray(`Prompt: ${flags.prompt}`));
-      if (flags.style) {
-        this.log(chalk.blue(`🎨 Style: ${flags.style}`));
-      }
-      if (flags["raw-prompt"]) {
-        this.log(chalk.yellow("⚠️  Using raw prompt (no style enhancement)"));
-      }
-
       if (provider === "banana") {
-        if (!flags.pro) {
+        if (bananaVariant === "banana 2") {
+          if (requestedN !== 1) {
+            this.error(chalk.red("Banana 2 only supports -n 1"));
+          }
+        } else if (!flags.pro) {
           if (requestedN !== 1) {
             this.error(chalk.red("Banana normal only supports -n 1"));
           }
@@ -425,14 +449,34 @@ export default class IconCommand extends Command {
             }
           }
         }
+      }
 
+      this.log(chalk.blue("🎨 Generating your app icon..."));
+      this.log("");
+      this.log(CTA);
+      this.log("");
+      this.log(chalk.gray(`Prompt: ${flags.prompt}`));
+      if (flags.style) {
+        this.log(chalk.blue(`🎨 Style: ${flags.style}`));
+      }
+      if (flags["raw-prompt"]) {
+        this.log(chalk.yellow("⚠️  Using raw prompt (no style enhancement)"));
+      }
+
+      if (provider === "banana") {
         const bananaQuality = this.resolveBananaQuality(qualityInput);
+        const thinkingLevel =
+          bananaVariant === "banana 2" && flags.thinking
+            ? (flags.thinking as "minimal" | "max")
+            : undefined;
         const images = await GeminiService.generateBananaImages({
           prompt: finalPrompt,
           pro: flags.pro,
-          n: flags.pro ? requestedN : 1,
+          n: bananaVariant === "banana 2" ? 1 : flags.pro ? requestedN : 1,
           quality: bananaQuality,
           apiKey: flags["google-api-key"],
+          modelVariant: bananaVariant,
+          thinkingLevel,
         });
 
         const outputPaths = await this.saveBinaryImages(images, flags.output);

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -2,8 +2,11 @@ import { GoogleGenAI } from "@google/genai";
 import mime from "mime";
 import { ConfigService } from "./config.js";
 
-export type BananaModel = "banana";
+export type BananaModel = "banana" | "banana 2";
 export type BananaQuality = "1k" | "2k" | "4k";
+
+/** CLI values for banana 2 thinking level; maps to ThinkingLevel in the API. */
+export type Banana2ThinkingLevel = "minimal" | "max";
 
 export interface BananaGenerateOptions {
   prompt: string;
@@ -11,6 +14,10 @@ export interface BananaGenerateOptions {
   n: number;
   quality: BananaQuality;
   apiKey?: string;
+  /** When set to "banana 2", uses nano banana 2 (gemini-3.1-flash-image-preview) with thinking config. */
+  modelVariant?: BananaModel;
+  /** Only used when modelVariant is "banana 2". Sent as thinkingConfig.thinkingLevel (MINIMAL | HIGH). */
+  thinkingLevel?: Banana2ThinkingLevel;
 }
 
 export interface GeneratedBinaryImage {
@@ -21,6 +28,7 @@ export interface GeneratedBinaryImage {
 
 const BANANA_NORMAL_MODEL = "gemini-2.5-flash-image";
 const BANANA_PRO_MODEL = "gemini-3-pro-image-preview";
+const BANANA_2_MODEL = "gemini-3.1-flash-image-preview";
 
 function mapQualityToImageSize(q: BananaQuality): "1K" | "2K" | "4K" {
   if (q === "2k") return "2K";
@@ -65,7 +73,19 @@ export class GeminiService {
     options: BananaGenerateOptions
   ): Promise<GeneratedBinaryImage[]> {
     const ai = await this.getClient(options.apiKey);
-    const { prompt, pro, n, quality } = options;
+    const { prompt, pro, n, quality, modelVariant } = options;
+
+    if (modelVariant === "banana 2") {
+      return await this.generateStream(
+        ai,
+        BANANA_2_MODEL,
+        prompt,
+        1,
+        undefined,
+        "banana 2",
+        options.thinkingLevel
+      );
+    }
 
     if (!pro) {
       return await this.generateStream(ai, BANANA_NORMAL_MODEL, prompt, 1);
@@ -90,18 +110,36 @@ export class GeminiService {
     return results;
   }
 
+  /** Map CLI thinking level to API ThinkingLevel (see @google/genai ThinkingLevel enum). */
+  private static mapThinkingLevel(
+    level: Banana2ThinkingLevel | undefined
+  ): "MINIMAL" | "HIGH" | undefined {
+    if (!level) return undefined;
+    return level === "max" ? "HIGH" : "MINIMAL";
+  }
+
   private static async generateStream(
     ai: GoogleGenAI,
     model: string,
     prompt: string,
     desired: number,
-    quality?: BananaQuality
+    quality?: BananaQuality,
+    variant?: "banana 2",
+    thinkingLevel?: Banana2ThinkingLevel
   ): Promise<GeneratedBinaryImage[]> {
     const config: any = {
       responseModalities: ["IMAGE", "TEXT"],
     };
 
-    if (model === BANANA_PRO_MODEL && quality) {
+    if (variant === "banana 2") {
+      config.imageConfig = { imageSize: "1K" };
+      const level = this.mapThinkingLevel(thinkingLevel);
+      if (level !== undefined) {
+        config.thinkingConfig = { thinkingLevel: level };
+      } else {
+        config.thinkingConfig = { thinkingLevel: "MINIMAL" };
+      }
+    } else if (model === BANANA_PRO_MODEL && quality) {
       config.imageConfig = {
         imageSize: mapQualityToImageSize(quality),
       };

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -2,7 +2,7 @@ import { GoogleGenAI } from "@google/genai";
 import mime from "mime";
 import { ConfigService } from "./config.js";
 
-export type BananaModel = "banana" | "banana 2";
+export type BananaModel = "banana" | "banana-2";
 export type BananaQuality = "1k" | "2k" | "4k";
 
 /** CLI values for banana 2 thinking level; maps to ThinkingLevel in the API. */
@@ -14,9 +14,9 @@ export interface BananaGenerateOptions {
   n: number;
   quality: BananaQuality;
   apiKey?: string;
-  /** When set to "banana 2", uses nano banana 2 (gemini-3.1-flash-image-preview) with thinking config. */
+  /** When set to "banana-2", uses nano banana 2 (gemini-3.1-flash-image-preview) with thinking config. */
   modelVariant?: BananaModel;
-  /** Only used when modelVariant is "banana 2". Sent as thinkingConfig.thinkingLevel (MINIMAL | HIGH). */
+  /** Only used when modelVariant is "banana-2". Sent as thinkingConfig.thinkingLevel (MINIMAL | HIGH). */
   thinkingLevel?: Banana2ThinkingLevel;
 }
 
@@ -75,14 +75,14 @@ export class GeminiService {
     const ai = await this.getClient(options.apiKey);
     const { prompt, pro, n, quality, modelVariant } = options;
 
-    if (modelVariant === "banana 2") {
+    if (modelVariant === "banana-2") {
       return await this.generateStream(
         ai,
         BANANA_2_MODEL,
         prompt,
         1,
         undefined,
-        "banana 2",
+        "banana-2",
         options.thinkingLevel
       );
     }
@@ -124,14 +124,14 @@ export class GeminiService {
     prompt: string,
     desired: number,
     quality?: BananaQuality,
-    variant?: "banana 2",
+    variant?: "banana-2",
     thinkingLevel?: Banana2ThinkingLevel
   ): Promise<GeneratedBinaryImage[]> {
     const config: any = {
       responseModalities: ["IMAGE", "TEXT"],
     };
 
-    if (variant === "banana 2") {
+    if (variant === "banana-2") {
       config.imageConfig = { imageSize: "1K" };
       const level = this.mapThinkingLevel(thinkingLevel);
       if (level !== undefined) {


### PR DESCRIPTION
- Introduced a new CLI flag for the "banana 2" model, allowing users to specify thinking levels.
- Updated the icon command description and examples to reflect the new model.
- Enhanced the Gemini service to handle requests for the "banana 2" model.
- Revised the README to include details about the new model and its usage.