### PR TITLE
feat: Add feature-graphic command for Google Play Store banners

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,14 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@google/genai": "^1.0.0",
     "@oclif/core": "^4.0.0",
     "@oclif/plugin-help": "^6.0.0",
-    "@google/genai": "^1.0.0",
-    "openai": "^4.20.1",
+    "chalk": "^5.3.0",
     "fs-extra": "^11.1.1",
     "mime": "^4.0.0",
-    "chalk": "^5.3.0"
+    "openai": "^4.20.1",
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       openai:
         specifier: ^4.20.1
         version: 4.104.0(ws@8.19.0)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
@@ -236,6 +239,9 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -275,6 +281,143 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -942,6 +1085,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -1966,12 +2113,21 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2121,6 +2277,9 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2494,6 +2653,11 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
@@ -2538,6 +2702,102 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3369,6 +3629,8 @@ snapshots:
   deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
+
+  detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
 
@@ -4563,6 +4825,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  semver@7.7.4: {}
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
@@ -4570,6 +4834,37 @@ snapshots:
   shallow-clone@3.0.1:
     dependencies:
       kind-of: 6.0.3
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -4704,6 +4999,9 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tslib@2.8.1:
+    optional: true
 
   type-check@0.4.0:
     dependencies:

--- a/src/commands/feature-graphic.ts
+++ b/src/commands/feature-graphic.ts
@@ -3,26 +3,15 @@ import fs from "fs-extra";
 import chalk from "chalk";
 import { OpenAIService } from "../services/openai.js";
 import { GeminiService } from "../services/gemini.js";
-import { ValidationService } from "../utils/validation.js";
+import { ValidationService, isStyleDangerous } from "../utils/validation.js";
 import { buildFeatureGraphicPrompt } from "../utils/fg-prompt.js";
 import { StyleTemplates } from "../utils/styleTemplates.js";
 import { CTA } from "../utils/branding.js";
-import { saveBase64Images, saveBinaryImages } from "../utils/save-images.js";
+import { saveBase64Images } from "../utils/save-images.js";
 import {
   resizeToFeatureGraphic,
   compositeLogoOnBanner,
 } from "../utils/image-processing.js";
-
-function isStyleDangerous(style?: string): boolean {
-  if (!style) return false;
-  const s = style.toLowerCase();
-  const banned = [
-    "photo", "photograph", "photoreal", "photorealistic", "portrait",
-    "headshot", "selfie", "concert", "wedding", "dslr", "35mm",
-    "cinematic still", "real person", "celebrity",
-  ];
-  return banned.some((k) => s.includes(k));
-}
 
 export default class FeatureGraphicCommand extends Command {
   static description =

--- a/src/commands/feature-graphic.ts
+++ b/src/commands/feature-graphic.ts
@@ -1,0 +1,401 @@
+import { Command, Flags } from "@oclif/core";
+import fs from "fs-extra";
+import chalk from "chalk";
+import { OpenAIService } from "../services/openai.js";
+import { GeminiService } from "../services/gemini.js";
+import { ValidationService } from "../utils/validation.js";
+import { buildFeatureGraphicPrompt } from "../utils/fg-prompt.js";
+import { StyleTemplates } from "../utils/styleTemplates.js";
+import { CTA } from "../utils/branding.js";
+import { saveBase64Images, saveBinaryImages } from "../utils/save-images.js";
+import {
+  resizeToFeatureGraphic,
+  compositeLogoOnBanner,
+} from "../utils/image-processing.js";
+
+function isStyleDangerous(style?: string): boolean {
+  if (!style) return false;
+  const s = style.toLowerCase();
+  const banned = [
+    "photo", "photograph", "photoreal", "photorealistic", "portrait",
+    "headshot", "selfie", "concert", "wedding", "dslr", "35mm",
+    "cinematic still", "real person", "celebrity",
+  ];
+  return banned.some((k) => s.includes(k));
+}
+
+export default class FeatureGraphicCommand extends Command {
+  static description =
+    "Generate AI-powered Google Play feature graphics (1024x500) using OpenAI or Gemini";
+
+  static aliases = ["fg"];
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --prompt "fitness tracker app"',
+    '<%= config.bin %> <%= command.id %> --prompt "fitness tracker" --app-name "FitTrack"',
+    '<%= config.bin %> <%= command.id %> --prompt "music player" --style neon --model gpt-1.5',
+    '<%= config.bin %> <%= command.id %> --prompt "weather app" --model banana --output-format jpeg',
+    '<%= config.bin %> <%= command.id %> --prompt "tracker" --logo ./assets/icon.png --logo-position left',
+    '<%= config.bin %> fg --prompt "calculator app" --prompt-only',
+  ];
+
+  static flags = {
+    prompt: Flags.string({
+      char: "p",
+      description: "Description of the feature graphic to generate",
+      required: true,
+    }),
+    output: Flags.string({
+      char: "o",
+      description: "Output directory",
+      default: "./assets",
+    }),
+    "prompt-only": Flags.boolean({
+      description: "Preview the final prompt without generating images",
+      default: false,
+    }),
+    "openai-api-key": Flags.string({
+      char: "k",
+      description:
+        "OpenAI API key override. Also supports SNAPAI_API_KEY / OPENAI_API_KEY",
+    }),
+    "google-api-key": Flags.string({
+      char: "g",
+      description:
+        "Google Studio API key override. Also supports SNAPAI_GOOGLE_API_KEY / GEMINI_API_KEY",
+    }),
+    model: Flags.string({
+      char: "m",
+      description:
+        'Model: OpenAI ("gpt-1.5" or "gpt-1") or Gemini ("banana" or "banana-2")',
+      default: "gpt-1.5",
+      options: ["gpt-1.5", "gpt-1", "banana", "banana-2", "gpt"],
+    }),
+    quality: Flags.string({
+      char: "q",
+      description: "Quality level (depends on model)",
+      default: "auto",
+      options: [
+        "auto", "standard", "hd", "high", "medium", "low",
+        "1k", "2k", "4k",
+      ],
+    }),
+    "output-format": Flags.string({
+      char: "f",
+      description: "Output format: png or jpeg (no webp per Google Play spec)",
+      default: "png",
+      options: ["png", "jpeg"],
+    }),
+    n: Flags.integer({
+      char: "n",
+      description: "Number of images (max 10)",
+      default: 1,
+      min: 1,
+      max: 10,
+    }),
+    moderation: Flags.string({
+      description: "Content filtering: low, auto (GPT only)",
+      default: "auto",
+      options: ["low", "auto"],
+    }),
+    "raw-prompt": Flags.boolean({
+      char: "r",
+      description: "Send the prompt as-is (no enhancement)",
+      default: false,
+    }),
+    style: Flags.string({
+      char: "s",
+      description: "Optional style hint",
+    }),
+    "app-name": Flags.string({
+      description: "App name to include as text on the banner",
+    }),
+    logo: Flags.string({
+      description: "Path to a logo file to composite onto the banner",
+    }),
+    "logo-position": Flags.string({
+      description: "Logo position on the banner",
+      default: "left",
+      options: ["left", "center", "right"],
+    }),
+    pro: Flags.boolean({
+      char: "P",
+      description: "Use Gemini Pro model (banana only)",
+      default: false,
+    }),
+    thinking: Flags.string({
+      description: "Thinking level for banana-2: minimal or max",
+      options: ["minimal", "max"],
+    }),
+  };
+
+  private resolveOpenAIQuality(
+    input: string
+  ): "auto" | "high" | "medium" | "low" {
+    const q = input.trim().toLowerCase();
+    if (q === "hd") return "high";
+    if (q === "standard") return "medium";
+    if (q === "auto" || q === "high" || q === "medium" || q === "low") return q;
+    throw new Error(
+      `Invalid --quality "${input}" for OpenAI models. Valid: auto|high|medium|low`
+    );
+  }
+
+  private resolveBananaQuality(input: string): "1k" | "2k" | "4k" {
+    const q = input.trim().toLowerCase();
+    if (q === "auto") return "1k";
+    if (q === "1k" || q === "2k" || q === "4k") return q;
+    throw new Error(
+      `Invalid --quality "${input}" for banana. Valid: 1k|2k|4k (or auto)`
+    );
+  }
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(FeatureGraphicCommand);
+
+    try {
+      const promptError = ValidationService.validatePrompt(flags.prompt);
+      if (promptError) this.error(promptError);
+
+      const outputError = ValidationService.validateOutputPath(flags.output);
+      if (outputError) this.error(outputError);
+
+      if (isStyleDangerous(flags.style)) {
+        this.error(
+          chalk.red(
+            "Blocked: --style contains photo/portrait keywords. Use a rendering style instead."
+          )
+        );
+      }
+
+      if (flags.logo) {
+        const logoExists = await fs.pathExists(flags.logo);
+        if (!logoExists) {
+          this.error(chalk.red(`Logo file not found: ${flags.logo}`));
+        }
+      }
+
+      const modelFlag = flags.model as string;
+      const normalizedModelFlag =
+        String(modelFlag || "").trim().toLowerCase() === "gpt"
+          ? "gpt-1.5"
+          : modelFlag;
+      const provider: "banana" | "openai" =
+        normalizedModelFlag === "banana" || normalizedModelFlag === "banana-2"
+          ? "banana"
+          : "openai";
+      const bananaVariant: "banana" | "banana-2" | undefined =
+        normalizedModelFlag === "banana-2"
+          ? "banana-2"
+          : normalizedModelFlag === "banana"
+            ? "banana"
+            : undefined;
+      const openaiModel =
+        provider === "openai"
+          ? (normalizedModelFlag as "gpt-1" | "gpt-1.5" | "gpt")
+          : undefined;
+
+      const qualityInput = (
+        Array.isArray(flags.quality)
+          ? String(flags.quality[0] ?? "auto")
+          : typeof flags.quality === "string"
+            ? flags.quality
+            : "auto"
+      );
+
+      if (flags.thinking && bananaVariant !== "banana-2") {
+        this.error(
+          chalk.red("--thinking is only supported with --model banana-2")
+        );
+      }
+
+      if (flags["openai-api-key"]) {
+        const keyError = ValidationService.validateApiKey(
+          flags["openai-api-key"]
+        );
+        if (keyError) this.error(chalk.red(keyError));
+      }
+      if (flags["google-api-key"]) {
+        const keyError = ValidationService.validateGoogleApiKey(
+          flags["google-api-key"]
+        );
+        if (keyError) this.error(chalk.red(keyError));
+      }
+
+      const requestedN = flags.n;
+      const outputFormat = flags["output-format"] as "png" | "jpeg";
+
+      const finalPrompt = buildFeatureGraphicPrompt({
+        prompt: flags.prompt,
+        rawPrompt: flags["raw-prompt"],
+        style: flags.style,
+        appName: flags["app-name"],
+      });
+
+      // Prompt-only mode
+      if (flags["prompt-only"]) {
+        const styleInput = flags.style?.trim();
+        const styleNormalized = styleInput?.toLowerCase();
+        const availableStyles = StyleTemplates.getAvailableStyles().map((s) =>
+          String(s).toLowerCase()
+        );
+        const isPresetStyle = Boolean(
+          styleNormalized && availableStyles.includes(styleNormalized)
+        );
+
+        this.log(chalk.blue("🔎 Prompt preview (no generation)"));
+        this.log("");
+        this.log(chalk.gray(`Raw prompt: ${flags.prompt}`));
+        this.log(chalk.gray(`Enhanced: ${flags["raw-prompt"] ? "no" : "yes"}`));
+        if (flags["app-name"]) {
+          this.log(chalk.gray(`App name: ${flags["app-name"]}`));
+        }
+        this.log(
+          chalk.gray(
+            `Style: ${
+              styleInput
+                ? `${styleInput}${isPresetStyle ? " (preset)" : " (custom)"}`
+                : "none"
+            }`
+          )
+        );
+        if (styleInput && isPresetStyle) {
+          this.log(
+            chalk.dim(
+              `Style summary: ${StyleTemplates.getStyleDescription(
+                styleNormalized as any
+              )}`
+            )
+          );
+        }
+        this.log("");
+        this.log(chalk.gray("Configuration:"));
+        this.log(chalk.gray(`  provider: ${provider}`));
+        this.log(chalk.gray(`  model: ${normalizedModelFlag}`));
+        this.log(chalk.gray(`  output size: 1024x500 (feature graphic)`));
+        this.log(chalk.gray(`  output format: ${outputFormat}`));
+        this.log(chalk.gray(`  n: ${requestedN}`));
+        if (flags.logo) {
+          this.log(chalk.gray(`  logo: ${flags.logo}`));
+          this.log(
+            chalk.gray(`  logo-position: ${flags["logo-position"]}`)
+          );
+        }
+        this.log("");
+        this.log(chalk.gray("Final prompt (sent to the model):"));
+        this.log("");
+        this.log(finalPrompt);
+        return;
+      }
+
+      this.log(chalk.blue("🖼️  Generating your feature graphic..."));
+      this.log("");
+      this.log(CTA);
+      this.log("");
+      this.log(chalk.gray(`Prompt: ${flags.prompt}`));
+      if (flags["app-name"]) {
+        this.log(chalk.gray(`App name: ${flags["app-name"]}`));
+      }
+      if (flags.style) {
+        this.log(chalk.blue(`🎨 Style: ${flags.style}`));
+      }
+      if (flags["raw-prompt"]) {
+        this.log(chalk.yellow("⚠️  Using raw prompt (no enhancement)"));
+      }
+
+      let imageBuffers: Buffer[] = [];
+
+      if (provider === "banana") {
+        if (bananaVariant === "banana-2") {
+          if (requestedN !== 1) {
+            this.error(chalk.red("banana-2 only supports -n 1"));
+          }
+        } else if (!flags.pro) {
+          if (requestedN !== 1) {
+            this.error(chalk.red("Banana normal only supports -n 1"));
+          }
+        }
+
+        const bananaQuality = this.resolveBananaQuality(qualityInput);
+        const thinkingLevel =
+          bananaVariant === "banana-2" && flags.thinking
+            ? (flags.thinking as "minimal" | "max")
+            : undefined;
+
+        const images = await GeminiService.generateBananaImages({
+          prompt: finalPrompt,
+          pro: flags.pro,
+          n: bananaVariant === "banana-2" ? 1 : flags.pro ? requestedN : 1,
+          quality: bananaQuality,
+          apiKey: flags["google-api-key"],
+          modelVariant: bananaVariant,
+          thinkingLevel,
+          aspectRatio: "16:9",
+        });
+
+        imageBuffers = images.map((img) => Buffer.from(img.base64, "base64"));
+      } else {
+        // OpenAI
+        const openaiQuality = this.resolveOpenAIQuality(qualityInput);
+        const base64Array = await OpenAIService.generateIcon({
+          prompt: finalPrompt,
+          output: flags.output,
+          model: openaiModel,
+          quality: openaiQuality,
+          background: "opaque",
+          outputFormat: outputFormat,
+          numImages: requestedN,
+          moderation: flags.moderation as "low" | "auto",
+          rawPrompt: true,
+          apiKey: flags["openai-api-key"],
+          size: "1536x1024",
+        });
+
+        imageBuffers = base64Array.map((b64) => Buffer.from(b64, "base64"));
+      }
+
+      // Post-process: resize to 1024x500
+      this.log(chalk.gray("📐 Resizing to 1024x500..."));
+      const processedBuffers: Buffer[] = [];
+      for (const buf of imageBuffers) {
+        let processed = await resizeToFeatureGraphic(buf, outputFormat);
+        if (flags.logo) {
+          processed = await compositeLogoOnBanner(
+            processed,
+            flags.logo,
+            flags["logo-position"] as "left" | "center" | "right"
+          );
+        }
+        processedBuffers.push(processed);
+      }
+
+      // Save
+      this.log(chalk.gray(`💾 Saving ${processedBuffers.length} image(s)...`));
+      const base64Results = processedBuffers.map((buf) =>
+        buf.toString("base64")
+      );
+      const outputPaths = await saveBase64Images(
+        base64Results,
+        flags.output,
+        outputFormat,
+        "feature-graphic"
+      );
+
+      this.log(chalk.green("✅ Feature graphic(s) generated successfully!"));
+      if (outputPaths.length === 1) {
+        this.log(chalk.gray(`Saved to: ${outputPaths[0]}`));
+      } else {
+        this.log(chalk.gray(`Saved ${outputPaths.length} images to:`));
+        outputPaths.forEach((p, index) => {
+          this.log(chalk.gray(`  ${index + 1}. ${p}`));
+        });
+      }
+    } catch (error) {
+      this.error(
+        chalk.red(
+          `Failed to generate feature graphic: ${(error as Error).message}`
+        )
+      );
+    }
+  }
+}

--- a/src/commands/icon.ts
+++ b/src/commands/icon.ts
@@ -1,6 +1,4 @@
 import { Command, Flags } from "@oclif/core";
-import fs from "fs-extra";
-import path from "path";
 import chalk from "chalk";
 import { OpenAIService } from "../services/openai.js";
 import { GeminiService } from "../services/gemini.js";
@@ -8,6 +6,7 @@ import { ValidationService } from "../utils/validation.js";
 import { buildFinalIconPrompt } from "../utils/icon-prompt.js";
 import { StyleTemplates } from "../utils/styleTemplates.js";
 import { CTA } from "../utils/branding.js";
+import { saveBase64Images, saveBinaryImages } from "../utils/save-images.js";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 
@@ -479,7 +478,8 @@ export default class IconCommand extends Command {
           thinkingLevel,
         });
 
-        const outputPaths = await this.saveBinaryImages(images, flags.output);
+        this.log(chalk.gray(`💾 Saving ${images.length} image(s)...`));
+        const outputPaths = await saveBinaryImages(images, flags.output);
         this.log(chalk.green("✅ Icon(s) generated successfully!"));
         if (outputPaths.length === 1) {
           this.log(chalk.gray(`Saved to: ${outputPaths[0]}`));
@@ -508,7 +508,8 @@ export default class IconCommand extends Command {
         apiKey: openaiApiKey,
       });
 
-      const outputPaths = await this.saveBase64Images(
+      this.log(chalk.gray(`💾 Saving ${imageBase64Array.length} image(s)...`));
+      const outputPaths = await saveBase64Images(
         imageBase64Array,
         flags.output,
         outputFormat
@@ -542,67 +543,4 @@ export default class IconCommand extends Command {
     }
   }
 
-  private async saveBase64Images(
-    base64DataArray: string[],
-    outputDir: string,
-    outputFormat: string
-  ): Promise<string[]> {
-    await fs.ensureDir(outputDir);
-
-    const outputPaths: string[] = [];
-    const timestamp = Date.now();
-
-    try {
-      this.log(chalk.gray(`💾 Saving ${base64DataArray.length} image(s)...`));
-
-      for (let i = 0; i < base64DataArray.length; i++) {
-        const base64Data = base64DataArray[i];
-        const extension = outputFormat || "png";
-        const filename =
-          base64DataArray.length === 1
-            ? `icon-${timestamp}.${extension}`
-            : `icon-${timestamp}-${i + 1}.${extension}`;
-        const outputPath = path.join(outputDir, filename);
-
-        // Convert base64 to buffer
-        const buffer = Buffer.from(base64Data, "base64");
-        await fs.writeFile(outputPath, buffer);
-
-        outputPaths.push(outputPath);
-      }
-
-      return outputPaths;
-    } catch (error: any) {
-      throw new Error(`Failed to save image(s): ${error.message}`);
-    }
-  }
-
-  private async saveBinaryImages(
-    images: Array<{ base64: string; extension: string }>,
-    outputDir: string
-  ): Promise<string[]> {
-    await fs.ensureDir(outputDir);
-    const outputPaths: string[] = [];
-    const timestamp = Date.now();
-
-    try {
-      this.log(chalk.gray(`💾 Saving ${images.length} image(s)...`));
-
-      for (let i = 0; i < images.length; i++) {
-        const { base64, extension } = images[i];
-        const filename =
-          images.length === 1
-            ? `icon-${timestamp}.${extension}`
-            : `icon-${timestamp}-${i + 1}.${extension}`;
-        const outputPath = path.join(outputDir, filename);
-        const buffer = Buffer.from(base64, "base64");
-        await fs.writeFile(outputPath, buffer);
-        outputPaths.push(outputPath);
-      }
-
-      return outputPaths;
-    } catch (error: any) {
-      throw new Error(`Failed to save image(s): ${error.message}`);
-    }
-  }
 }

--- a/src/commands/icon.ts
+++ b/src/commands/icon.ts
@@ -2,35 +2,13 @@ import { Command, Flags } from "@oclif/core";
 import chalk from "chalk";
 import { OpenAIService } from "../services/openai.js";
 import { GeminiService } from "../services/gemini.js";
-import { ValidationService } from "../utils/validation.js";
+import { ValidationService, isStyleDangerous } from "../utils/validation.js";
 import { buildFinalIconPrompt } from "../utils/icon-prompt.js";
 import { StyleTemplates } from "../utils/styleTemplates.js";
 import { CTA } from "../utils/branding.js";
 import { saveBase64Images, saveBinaryImages } from "../utils/save-images.js";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-
-function isStyleDangerous(style?: string): boolean {
-  if (!style) return false;
-  const s = style.toLowerCase();
-  const banned = [
-    "photo",
-    "photograph",
-    "photoreal",
-    "photorealistic",
-    "portrait",
-    "headshot",
-    "selfie",
-    "concert",
-    "wedding",
-    "dslr",
-    "35mm",
-    "cinematic still",
-    "real person",
-    "celebrity",
-  ];
-  return banned.some((k) => s.includes(k));
-}
 
 export default class IconCommand extends Command {
   static description =

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -18,6 +18,8 @@ export interface BananaGenerateOptions {
   modelVariant?: BananaModel;
   /** Only used when modelVariant is "banana-2". Sent as thinkingConfig.thinkingLevel (MINIMAL | HIGH). */
   thinkingLevel?: Banana2ThinkingLevel;
+  /** Optional aspect ratio override (e.g. "16:9"). Passed to imageConfig.aspectRatio. */
+  aspectRatio?: string;
 }
 
 export interface GeneratedBinaryImage {
@@ -83,16 +85,17 @@ export class GeminiService {
         1,
         undefined,
         "banana-2",
-        options.thinkingLevel
+        options.thinkingLevel,
+        options.aspectRatio
       );
     }
 
     if (!pro) {
-      return await this.generateStream(ai, BANANA_NORMAL_MODEL, prompt, 1);
+      return await this.generateStream(ai, BANANA_NORMAL_MODEL, prompt, 1, undefined, undefined, undefined, options.aspectRatio);
     }
 
     if (n <= 1) {
-      return await this.generateStream(ai, BANANA_PRO_MODEL, prompt, 1, quality);
+      return await this.generateStream(ai, BANANA_PRO_MODEL, prompt, 1, quality, undefined, undefined, options.aspectRatio);
     }
 
     const results = await Promise.all(
@@ -102,7 +105,10 @@ export class GeminiService {
           BANANA_PRO_MODEL,
           prompt,
           1,
-          quality
+          quality,
+          undefined,
+          undefined,
+          options.aspectRatio
         );
         return imgs[0];
       })
@@ -125,7 +131,8 @@ export class GeminiService {
     desired: number,
     quality?: BananaQuality,
     variant?: "banana-2",
-    thinkingLevel?: Banana2ThinkingLevel
+    thinkingLevel?: Banana2ThinkingLevel,
+    aspectRatio?: string
   ): Promise<GeneratedBinaryImage[]> {
     const config: any = {
       responseModalities: ["IMAGE", "TEXT"],
@@ -143,6 +150,10 @@ export class GeminiService {
       config.imageConfig = {
         imageSize: mapQualityToImageSize(quality),
       };
+    }
+
+    if (aspectRatio) {
+      config.imageConfig = { ...config.imageConfig, aspectRatio };
     }
 
     const contents = [

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -78,38 +78,32 @@ export class GeminiService {
     const { prompt, pro, n, quality, modelVariant } = options;
 
     if (modelVariant === "banana-2") {
-      return await this.generateStream(
-        ai,
-        BANANA_2_MODEL,
-        prompt,
-        1,
-        undefined,
-        "banana-2",
-        options.thinkingLevel,
-        options.aspectRatio
-      );
+      return await this.generateStream(ai, BANANA_2_MODEL, prompt, 1, {
+        variant: "banana-2",
+        thinkingLevel: options.thinkingLevel,
+        aspectRatio: options.aspectRatio,
+      });
     }
 
     if (!pro) {
-      return await this.generateStream(ai, BANANA_NORMAL_MODEL, prompt, 1, undefined, undefined, undefined, options.aspectRatio);
+      return await this.generateStream(ai, BANANA_NORMAL_MODEL, prompt, 1, {
+        aspectRatio: options.aspectRatio,
+      });
     }
 
     if (n <= 1) {
-      return await this.generateStream(ai, BANANA_PRO_MODEL, prompt, 1, quality, undefined, undefined, options.aspectRatio);
+      return await this.generateStream(ai, BANANA_PRO_MODEL, prompt, 1, {
+        quality,
+        aspectRatio: options.aspectRatio,
+      });
     }
 
     const results = await Promise.all(
       Array.from({ length: n }, async () => {
-        const imgs = await this.generateStream(
-          ai,
-          BANANA_PRO_MODEL,
-          prompt,
-          1,
+        const imgs = await this.generateStream(ai, BANANA_PRO_MODEL, prompt, 1, {
           quality,
-          undefined,
-          undefined,
-          options.aspectRatio
-        );
+          aspectRatio: options.aspectRatio,
+        });
         return imgs[0];
       })
     );
@@ -129,11 +123,14 @@ export class GeminiService {
     model: string,
     prompt: string,
     desired: number,
-    quality?: BananaQuality,
-    variant?: "banana-2",
-    thinkingLevel?: Banana2ThinkingLevel,
-    aspectRatio?: string
+    opts?: {
+      quality?: BananaQuality;
+      variant?: "banana-2";
+      thinkingLevel?: Banana2ThinkingLevel;
+      aspectRatio?: string;
+    }
   ): Promise<GeneratedBinaryImage[]> {
+    const { quality, variant, thinkingLevel, aspectRatio } = opts ?? {};
     const config: any = {
       responseModalities: ["IMAGE", "TEXT"],
     };

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -67,7 +67,7 @@ export class OpenAIService {
       model: resolvedModelId,
       prompt: finalPrompt,
       n: numImages,
-      size: this.FIXED_SIZE as any,
+      size: (options.size ?? this.FIXED_SIZE) as any,
     };
 
     // OpenAI image parameters

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface IconGenerationOptions {
   moderation?: 'low' | 'auto';
   rawPrompt?: boolean;
   apiKey?: string;
+  size?: string;
 }
 
 export interface OpenAIResponse {

--- a/src/utils/fg-prompt.ts
+++ b/src/utils/fg-prompt.ts
@@ -1,14 +1,4 @@
-import { StyleTemplates, type IconStyle } from "./styleTemplates.js";
-
-function resolveStylePreset(style?: string): { preset?: IconStyle; text?: string } {
-  if (!style) return {};
-  const normalized = style.trim().toLowerCase();
-  const available = StyleTemplates.getAvailableStyles() as readonly string[];
-  if (available.includes(normalized)) {
-    return { preset: normalized as IconStyle };
-  }
-  return { text: style.trim() };
-}
+import { StyleTemplates } from "./styleTemplates.js";
 
 export function buildFeatureGraphicPrompt(params: {
   prompt: string;
@@ -18,7 +8,7 @@ export function buildFeatureGraphicPrompt(params: {
 }): string {
   const { prompt, rawPrompt = false, style, appName } = params;
 
-  const styleResolved = resolveStylePreset(style);
+  const styleResolved = StyleTemplates.resolveStylePreset(style);
   const presetDirective = styleResolved.preset
     ? StyleTemplates.getStyleDirective(styleResolved.preset)
     : null;

--- a/src/utils/fg-prompt.ts
+++ b/src/utils/fg-prompt.ts
@@ -1,0 +1,107 @@
+import { StyleTemplates, type IconStyle } from "./styleTemplates.js";
+
+function resolveStylePreset(style?: string): { preset?: IconStyle; text?: string } {
+  if (!style) return {};
+  const normalized = style.trim().toLowerCase();
+  const available = StyleTemplates.getAvailableStyles() as readonly string[];
+  if (available.includes(normalized)) {
+    return { preset: normalized as IconStyle };
+  }
+  return { text: style.trim() };
+}
+
+export function buildFeatureGraphicPrompt(params: {
+  prompt: string;
+  rawPrompt?: boolean;
+  style?: string;
+  appName?: string;
+}): string {
+  const { prompt, rawPrompt = false, style, appName } = params;
+
+  const styleResolved = resolveStylePreset(style);
+  const presetDirective = styleResolved.preset
+    ? StyleTemplates.getStyleDirective(styleResolved.preset)
+    : null;
+
+  // Raw mode
+  if (rawPrompt) {
+    if (!styleResolved.preset && !styleResolved.text) {
+      return prompt;
+    }
+
+    if (styleResolved.preset && presetDirective) {
+      return [
+        `STYLE PRESET (dominant): ${styleResolved.preset}`,
+        `Style directive (must dominate all decisions): ${presetDirective}`,
+        ``,
+        `User prompt: ${prompt}`,
+      ].join("\n");
+    }
+
+    return [
+      `STYLE (dominant): ${styleResolved.text}`,
+      ``,
+      `User prompt: ${prompt}`,
+    ].join("\n");
+  }
+
+  const appNameLine = appName
+    ? `Include "${appName}" as large, bold, clearly readable text prominently placed on the banner.`
+    : null;
+
+  // Layer 1 - Context & concept
+  const layer1 = [
+    `Create a Google Play Store feature graphic — a landscape marketing banner (1024x500px).`,
+    `This is NOT an app icon. It is a billboard/hero-image composition for a store listing.`,
+    ``,
+    `Subject/theme: ${prompt}`,
+    ``,
+    appNameLine,
+    `Design direction:`,
+    `- Horizontal flow, bold high-contrast visuals`,
+    `- Main visual fills the frame with no large empty margins`,
+    `- Eye-catching at thumbnail size, professional at full size`,
+    `- Modern, polished promotional banner aesthetic`,
+    `- No device mockups, phone frames, or screenshots`,
+    `- No small text or fine details that won't read at thumbnail`,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+
+  // Layer 2 - Constraints
+  const layer2 = [
+    `Technical constraints:`,
+    `Landscape aspect ratio approximately 2:1 (1024x500).`,
+    `Main visual fills the frame — no large margins or padding.`,
+    `Safe zone: keep critical content (text, logo) within central 80%.`,
+    `Opaque background required (no transparency).`,
+    `Must be readable and impactful at thumbnail size.`,
+    `No text/typography unless explicitly requested via app name.`,
+    `No watermarks or logos unless explicitly requested.`,
+  ].join("\n");
+
+  // Layer 3 - Style
+  const styleLine = styleResolved.preset
+    ? [
+        `Primary style preset (dominant): ${styleResolved.preset}`,
+        `Style intent: ${StyleTemplates.getStyleDescription(styleResolved.preset)}`,
+        `Style directive (must dominate all decisions): ${presetDirective}`,
+        `Do not mix in other conflicting materials/styles.`,
+      ].join("\n")
+    : styleResolved.text
+      ? `Style: ${styleResolved.text}`
+      : null;
+
+  const layer3 = styleLine
+    ? [
+        ``,
+        `Style system:`,
+        styleResolved.preset
+          ? `This preset is the base art direction and is a HARD constraint. If any other instruction conflicts, the style rules win.`
+          : `Apply the style after the concept is defined.`,
+        styleLine,
+      ].join("\n")
+    : "";
+
+  return `${layer1}\n\n${layer2}${layer3}`;
+}

--- a/src/utils/icon-prompt.ts
+++ b/src/utils/icon-prompt.ts
@@ -1,4 +1,4 @@
-import { StyleTemplates, type IconStyle } from "./styleTemplates.js";
+import { StyleTemplates } from "./styleTemplates.js";
 
 // Shared "always-on" rules to prevent common generation failure modes.
 const ICON_BASE_CONTEXT_LINES = [
@@ -23,17 +23,6 @@ const ICON_BASE_RULES_LINES = [
   `Background extends to all four edges of the square canvas with straight (non-rounded) corners; keep it clean (low-detail, low-noise).`,
 ] as const;
 
-// Resolves `--style` into either a known preset or a free-form style string.
-function resolveStylePreset(style?: string): { preset?: IconStyle; text?: string } {
-  if (!style) return {};
-  const normalized = style.trim().toLowerCase();
-  const available = StyleTemplates.getAvailableStyles() as readonly string[];
-  if (available.includes(normalized)) {
-    return { preset: normalized as IconStyle };
-  }
-  return { text: style.trim() };
-}
-
 export function buildFinalIconPrompt(params: {
   prompt: string;
   rawPrompt?: boolean;
@@ -47,7 +36,7 @@ export function buildFinalIconPrompt(params: {
     useIconWords = false,
   } = params;
 
-  const styleResolved = resolveStylePreset(style);
+  const styleResolved = StyleTemplates.resolveStylePreset(style);
   const presetDirective = styleResolved.preset
     ? StyleTemplates.getStyleDirective(styleResolved.preset)
     : null;

--- a/src/utils/image-processing.ts
+++ b/src/utils/image-processing.ts
@@ -1,0 +1,43 @@
+import sharp from "sharp";
+
+export async function resizeToFeatureGraphic(
+  inputBuffer: Buffer,
+  format: "png" | "jpeg"
+): Promise<Buffer> {
+  let pipeline = sharp(inputBuffer)
+    .resize(1024, 500, { fit: "cover", position: "centre" })
+    .flatten({ background: "#ffffff" });
+
+  if (format === "jpeg") {
+    pipeline = pipeline.jpeg({ quality: 95 });
+  } else {
+    pipeline = pipeline.png();
+  }
+
+  return pipeline.toBuffer();
+}
+
+export async function compositeLogoOnBanner(
+  bannerBuffer: Buffer,
+  logoPath: string,
+  position: "left" | "center" | "right" = "left"
+): Promise<Buffer> {
+  const resizedLogo = await sharp(logoPath)
+    .resize(120, 120, { fit: "contain", background: { r: 0, g: 0, b: 0, alpha: 0 } })
+    .toBuffer();
+
+  const gravityMap: Record<string, string> = {
+    left: "west",
+    center: "centre",
+    right: "east",
+  };
+
+  return sharp(bannerBuffer)
+    .composite([
+      {
+        input: resizedLogo,
+        gravity: gravityMap[position] as any,
+      },
+    ])
+    .toBuffer();
+}

--- a/src/utils/save-images.ts
+++ b/src/utils/save-images.ts
@@ -1,0 +1,55 @@
+import fs from "fs-extra";
+import path from "path";
+
+export async function saveBase64Images(
+  base64DataArray: string[],
+  outputDir: string,
+  outputFormat: string,
+  filenamePrefix: string = "icon"
+): Promise<string[]> {
+  await fs.ensureDir(outputDir);
+
+  const outputPaths: string[] = [];
+  const timestamp = Date.now();
+
+  for (let i = 0; i < base64DataArray.length; i++) {
+    const base64Data = base64DataArray[i];
+    const extension = outputFormat || "png";
+    const filename =
+      base64DataArray.length === 1
+        ? `${filenamePrefix}-${timestamp}.${extension}`
+        : `${filenamePrefix}-${timestamp}-${i + 1}.${extension}`;
+    const outputPath = path.join(outputDir, filename);
+
+    const buffer = Buffer.from(base64Data, "base64");
+    await fs.writeFile(outputPath, buffer);
+
+    outputPaths.push(outputPath);
+  }
+
+  return outputPaths;
+}
+
+export async function saveBinaryImages(
+  images: Array<{ base64: string; extension: string }>,
+  outputDir: string,
+  filenamePrefix: string = "icon"
+): Promise<string[]> {
+  await fs.ensureDir(outputDir);
+  const outputPaths: string[] = [];
+  const timestamp = Date.now();
+
+  for (let i = 0; i < images.length; i++) {
+    const { base64, extension } = images[i];
+    const filename =
+      images.length === 1
+        ? `${filenamePrefix}-${timestamp}.${extension}`
+        : `${filenamePrefix}-${timestamp}-${i + 1}.${extension}`;
+    const outputPath = path.join(outputDir, filename);
+    const buffer = Buffer.from(base64, "base64");
+    await fs.writeFile(outputPath, buffer);
+    outputPaths.push(outputPath);
+  }
+
+  return outputPaths;
+}

--- a/src/utils/styleTemplates.ts
+++ b/src/utils/styleTemplates.ts
@@ -466,4 +466,14 @@ export class StyleTemplates {
     const def = STYLE_DEFINITIONS[style] || STYLE_DEFINITIONS.minimalism;
     return buildStyleDirective(def);
   }
+
+  static resolveStylePreset(style?: string): { preset?: IconStyle; text?: string } {
+    if (!style) return {};
+    const normalized = style.trim().toLowerCase();
+    const available = this.getAvailableStyles() as readonly string[];
+    if (available.includes(normalized)) {
+      return { preset: normalized as IconStyle };
+    }
+    return { text: style.trim() };
+  }
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,3 +1,15 @@
+const DANGEROUS_STYLE_KEYWORDS = [
+  "photo", "photograph", "photoreal", "photorealistic", "portrait",
+  "headshot", "selfie", "concert", "wedding", "dslr", "35mm",
+  "cinematic still", "real person", "celebrity",
+];
+
+export function isStyleDangerous(style?: string): boolean {
+  if (!style) return false;
+  const s = style.toLowerCase();
+  return DANGEROUS_STYLE_KEYWORDS.some((k) => s.includes(k));
+}
+
 export class ValidationService {
   static validatePrompt(prompt: string): string | null {
     if (!prompt || prompt.trim().length === 0) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ export default {
     'openai': 'openai',
     'fs-extra': 'fs-extra',
     'chalk': 'chalk',
+    'sharp': 'sharp',
     'fs': 'fs',
     'path': 'path',
     'os': 'os'


### PR DESCRIPTION
## Summary

- Add `snapai feature-graphic` (alias: `fg`) command that generates 1024x500px Google Play feature graphics using OpenAI or Gemini
- Add `sharp` dependency for post-processing (resize, flatten, logo compositing)
- Extract shared save helpers from icon command into reusable utils

## New flags

| Flag | Description |
|---|---|
| `--app-name` | App name to render as text on the banner |
| `--logo` | Logo file path to composite onto the banner |
| `--logo-position` | `left` / `center` / `right` (default: `left`) |
| `--output-format` | `png` / `jpeg` only (no webp per Google Play spec) |

## Test plan

- [ ] `pnpm run build` — no TS errors
- [ ] `snapai fg --prompt "fitness tracker app" --prompt-only` — verify prompt preview
- [ ] `snapai fg --prompt "fitness tracker" --model gpt-1.5` — generate with OpenAI, verify 1024x500 output
- [ ] `snapai fg --prompt "fitness tracker" --model banana` — generate with Gemini
- [ ] `snapai fg --prompt "tracker" --app-name "FitTrack" --style neon` — verify app name + style
- [ ] `snapai fg --prompt "tracker" --logo ./assets/icon.png --logo-position left` — verify logo composite
- [ ] `snapai icon --prompt "test"` — verify icon command still works unchanged

Closes #29