### PR TITLE
Fix CLI error double-wrapping, config read side effect, and stale flag docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "dev": "tsc --watch",
     "dev:cmd": "./dev-cli.js",
     "test": "jest",
-    "test:icon-batch": "bash scripts/test-icon-batch.sh",
     "lint": "eslint src/**/*.ts",
     "clean": "rm -rf dist bundle"
   },

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -41,7 +41,7 @@ export default class ConfigCommand extends Command {
       await this.showConfig();
     }
 
-    // If no flags provided, show help
+    // If no flags provided, show the current configuration
     if (Object.keys(flags).length === 0) {
       await this.showConfig();
     }

--- a/src/commands/feature-graphic.ts
+++ b/src/commands/feature-graphic.ts
@@ -1,4 +1,4 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Errors, Flags } from "@oclif/core";
 import fs from "fs-extra";
 import chalk from "chalk";
 import { OpenAIService } from "../services/openai.js";
@@ -223,6 +223,19 @@ export default class FeatureGraphicCommand extends Command {
 
       // Prompt-only mode
       if (flags["prompt-only"]) {
+        // Provider-specific validation (so the preview matches generation mode).
+        if (provider === "banana") {
+          if (bananaVariant === "banana-2" && requestedN !== 1) {
+            this.error(chalk.red("banana-2 only supports -n 1"));
+          }
+          if (bananaVariant === "banana" && !flags.pro && requestedN !== 1) {
+            this.error(chalk.red("Banana normal only supports -n 1"));
+          }
+          this.resolveBananaQuality(qualityInput);
+        } else {
+          this.resolveOpenAIQuality(qualityInput);
+        }
+
         const styleInput = flags.style?.trim();
         const styleNormalized = styleInput?.toLowerCase();
         const availableStyles = StyleTemplates.getAvailableStyles().map((s) =>
@@ -380,6 +393,11 @@ export default class FeatureGraphicCommand extends Command {
         });
       }
     } catch (error) {
+      // Errors raised via this.error() above are already user-facing CLI
+      // errors; re-throw them as-is instead of double-wrapping the message.
+      if (error instanceof Errors.CLIError) {
+        throw error;
+      }
       this.error(
         chalk.red(
           `Failed to generate feature graphic: ${(error as Error).message}`

--- a/src/commands/icon.ts
+++ b/src/commands/icon.ts
@@ -1,4 +1,4 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Errors, Flags } from "@oclif/core";
 import fs from "fs-extra";
 import path from "path";
 import chalk from "chalk";
@@ -134,13 +134,14 @@ export default class IconCommand extends Command {
     // === Advanced Options ===
     background: Flags.string({
       char: "b",
-      description: "Background: transparent, opaque, auto (GPT-Image-1 only)",
+      description:
+        "Background: transparent, opaque, auto (OpenAI only; transparent not supported by gpt-image-2)",
       default: "auto",
       options: ["transparent", "opaque", "auto"],
     }),
     "output-format": Flags.string({
       char: "f",
-      description: "Output format: png, jpeg, webp (GPT-Image-1 only)",
+      description: "Output format: png, jpeg, webp (OpenAI only)",
       default: "png",
       options: ["png", "jpeg", "webp"],
     }),
@@ -156,7 +157,7 @@ export default class IconCommand extends Command {
       hidden: true,
     }),
     moderation: Flags.string({
-      description: "Content filtering: low, auto (GPT-Image-1 only)",
+      description: "Content filtering: low, auto (OpenAI only)",
       default: "auto",
       options: ["low", "auto"],
     }),
@@ -330,6 +331,9 @@ export default class IconCommand extends Command {
             if (requestedN !== 1) {
               this.error(chalk.red("banana-2 only supports -n 1"));
             }
+            // Generation mode resolves banana quality for banana-2 too; run the
+            // same validation here so the preview matches real behavior.
+            this.resolveBananaQuality(qualityInput);
           } else if (!flags.pro) {
             if (requestedN !== 1) {
               this.error(chalk.red("Banana normal only supports -n 1"));
@@ -528,6 +532,11 @@ export default class IconCommand extends Command {
         });
       }
     } catch (error) {
+      // Errors raised via this.error() above are already user-facing CLI
+      // errors; re-throw them as-is instead of double-wrapping the message.
+      if (error instanceof Errors.CLIError) {
+        throw error;
+      }
       this.error(
         chalk.red(`Failed to generate icon: ${(error as Error).message}`)
       );

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -8,7 +8,10 @@ export class ConfigService {
 
   static async getConfig(): Promise<ConfigData> {
     try {
-      await fs.ensureFile(this.configPath);
+      // Read-only: don't create the config file as a side effect.
+      if (!(await fs.pathExists(this.configPath))) {
+        return {};
+      }
       const config = await fs.readJSON(this.configPath);
       return config;
     } catch {

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -47,7 +47,6 @@ export class OpenAIService {
       outputFormat = "png",
       numImages = 1,
       moderation = "auto",
-      rawPrompt = false,
     } = options;
 
     // Validate model-specific parameters
@@ -60,14 +59,12 @@ export class OpenAIService {
       moderation
     );
 
-    const finalPrompt = rawPrompt ? prompt : prompt;
-
     const resolvedModelId = this.resolveOpenAIImageModelId(model);
 
     // Build request parameters based on model
     const requestParams: ImageGenerateParams = {
       model: resolvedModelId,
-      prompt: finalPrompt,
+      prompt,
       n: numImages,
       size: this.FIXED_SIZE as any,
     };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,9 @@ export default {
     // Keep these as external dependencies
     '@oclif/core': '@oclif/core',
     '@oclif/plugin-help': '@oclif/plugin-help',
+    '@google/genai': '@google/genai',
     'openai': 'openai',
+    'mime': 'mime',
     'fs-extra': 'fs-extra',
     'chalk': 'chalk',
     'fs': 'fs',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Routine bug-scan pass over the codebase. Fixes several small but real bugs; no behavior additions.

> Updated after `main` merged the feature-graphic command (#30): conflicts resolved, and the same two bug patterns found in the icon command were also present in the new `feature-graphic` command, so they're fixed there too.

### Bug fixes

- **Double-wrapped error messages** (`src/commands/icon.ts`, `src/commands/feature-graphic.ts`): every `this.error(...)` inside `run()` throws an oclif `CLIError` that was caught by the outer `catch` and re-wrapped as `Failed to generate icon: <original red message>`. For example, `snapai icon -p x --model banana -n 2` printed a nested, double-styled message. The catch now re-throws `CLIError`s as-is and only wraps unexpected errors (API failures, save failures).

  Before:
  ```
  ›   Error: Failed to generate icon: Banana normal only supports -n 1
  ```
  After:
  ```
  ›   Error: Banana normal only supports -n 1
  ```

- **Config file created on read** (`src/services/config.ts`): `getConfig()` called `fs.ensureFile()`, so read-only commands like `snapai config --show` (or any generation using env-var keys) created an empty `~/.snapai/config.json` as a side effect. Reads now check `pathExists` instead.

- **Preview/generation validation mismatch** (`src/commands/icon.ts`, `src/commands/feature-graphic.ts`): `--prompt-only` skipped validation that generation mode performs. For `icon`, `--model banana-2 -q high --prompt-only` previewed fine but failed when actually generating. For `feature-graphic`, the preview skipped all provider-specific checks (`-n` limits and `--quality` resolution). Previews now run the same validation.

- **Broken npm script** (`package.json`): removed `test:icon-batch`, which points at `scripts/test-icon-batch.sh` — neither the script nor the `scripts/` directory exists in the repo.

- **Missing webpack externals** (`webpack.config.js`): `@google/genai` and `mime` were missing from `externals`, so `pnpm run bundle` inlined them while every other runtime dependency stayed external.

### Cleanup

- Removed dead ternary `rawPrompt ? prompt : prompt` in `src/services/openai.ts`.
- Fixed stale `(GPT-Image-1 only)` help text on `--background` / `--output-format` / `--moderation`; these apply to all OpenAI models (with a note that `gpt-image-2` rejects `transparent`).
- Fixed a misleading comment in the config command (no-flag invocation shows config, not help).

## Verification

- Merged latest `main` (including #30) into this branch; `pnpm run build`, `pnpm run lint`, and `pnpm run bundle` all pass.
- Manually verified with the built CLI:
  - `icon --model banana -n 2` and `fg --model banana -n 3 --prompt-only` → single clean error (no double wrapping); runtime errors (e.g. missing API key) still get the `Failed to generate ...:` prefix.
  - `config --show` with no `~/.snapai` → no file/directory created; `config --openai-api-key ...` still persists correctly.
  - `--model banana-2 -q high --prompt-only` now fails the same way generation mode does; normal `--prompt-only` previews (icon and feature-graphic, incl. `--app-name`/`--style`) unchanged.

## Related open work (not duplicated here)

- PR #33 — "Premature close" fix for large `gpt-image-2` responses
- PR #25 — baseURL configuration
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6848-0428-76d2-8693-24de2f9a9214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6848-0428-76d2-8693-24de2f9a9214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

