### PR TITLE
Support custom OpenAI base URL (completes #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ snapai config --google-api-key "your-google-ai-studio-key"
 snapai config --show
 ```
 
+### Custom OpenAI-compatible endpoint (optional)
+
+Point SnapAI at an OpenAI-compatible service (Azure OpenAI, OpenRouter, a local server, etc.) instead of `api.openai.com`:
+
+```bash
+snapai config --openai-base-url "https://my-proxy.example.com/v1"
+
+# Or via environment variable (takes precedence over the local config):
+export OPENAI_BASE_URL="https://my-proxy.example.com/v1"
+```
+
+To go back to the default endpoint, remove `openai_base_url` from `~/.snapai/config.json`.
+
 ### CI/CD secrets (recommended)
 
 Use environment variables so nothing is written to disk:

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -9,6 +9,7 @@ export default class ConfigCommand extends Command {
 
   static examples = [
     '<%= config.bin %> <%= command.id %> --openai-api-key sk-your-openai-key',
+    '<%= config.bin %> <%= command.id %> --openai-base-url https://my-proxy.example.com/v1',
     '<%= config.bin %> <%= command.id %> --show',
   ];
 
@@ -16,6 +17,9 @@ export default class ConfigCommand extends Command {
     'openai-api-key': Flags.string({
       char: 'k',
       description: 'Set OpenAI API key',
+    }),
+    'openai-base-url': Flags.string({
+      description: 'Set a custom OpenAI-compatible API base URL (e.g. Azure OpenAI, OpenRouter, local server)',
     }),
     'google-api-key': Flags.string({
       char: 'g',
@@ -31,6 +35,10 @@ export default class ConfigCommand extends Command {
 
     if (flags['openai-api-key']) {
       await this.setApiKey(flags['openai-api-key']);
+    }
+
+    if (flags['openai-base-url']) {
+      await this.setBaseUrl(flags['openai-base-url']);
     }
 
     if (flags['google-api-key']) {
@@ -59,6 +67,18 @@ export default class ConfigCommand extends Command {
     this.log(CTA);
   }
 
+  private async setBaseUrl(baseUrl: string): Promise<void> {
+    const error = ValidationService.validateBaseUrl(baseUrl);
+    if (error) {
+      this.error(chalk.red(error));
+    }
+
+    await ConfigService.set('openai_base_url', baseUrl);
+    this.log(chalk.green('✅ OpenAI base URL configured successfully!'));
+    this.log('');
+    this.log(CTA);
+  }
+
   private async setGoogleApiKey(apiKey: string): Promise<void> {
     const error = ValidationService.validateGoogleApiKey(apiKey);
     if (error) {
@@ -83,6 +103,10 @@ export default class ConfigCommand extends Command {
     } else {
       this.log(`🔑 OpenAI API Key: ${chalk.red('Not configured')}`);
       this.log(chalk.gray('   Set with: snapai config --openai-api-key YOUR_KEY'));
+    }
+
+    if (config.openai_base_url) {
+      this.log(`🌐 OpenAI Base URL: ${chalk.blue(config.openai_base_url)}`);
     }
 
     if (config.google_api_key) {

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -31,7 +31,10 @@ export class OpenAIService {
         "OpenAI API key not configured. Use SNAPAI_API_KEY / OPENAI_API_KEY, or run: snapai config --openai-api-key YOUR_KEY"
       );
     }
-    const baseURL = await ConfigService.get("openai_base_url");
+    // Same precedence as the API key: env var first, then local config.
+    const baseURL =
+      process.env.OPENAI_BASE_URL ||
+      (await ConfigService.get("openai_base_url"));
 
     return new OpenAI({
       apiKey: apiKey,

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -31,9 +31,11 @@ export class OpenAIService {
         "OpenAI API key not configured. Use SNAPAI_API_KEY / OPENAI_API_KEY, or run: snapai config --openai-api-key YOUR_KEY"
       );
     }
+    const baseURL = await ConfigService.get("openai_base_url");
 
     return new OpenAI({
       apiKey: apiKey,
+      baseURL: baseURL || undefined,
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface ConfigData {
   openai_api_key?: string;
+  openai_base_url?: string;
   google_api_key?: string;
   default_output_path?: string;
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -31,6 +31,18 @@ export class ValidationService {
     return null;
   }
 
+  static validateBaseUrl(baseUrl: string): string | null {
+    try {
+      const url = new URL(baseUrl);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return 'Base URL must use http:// or https://';
+      }
+    } catch {
+      return 'Invalid base URL format (expected e.g. https://my-proxy.example.com/v1)';
+    }
+    return null;
+  }
+
   static validateGoogleApiKey(apiKey: string): string | null {
     if (!apiKey || apiKey.trim().length === 0) {
       return 'Invalid Google API key format';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Supersedes #25 by @LastStranger (their commit is cherry-picked into this branch with authorship preserved) and adds the pieces needed to make the feature compile and be usable. Merging this PR delivers the feature requested in #25; #25 itself can then be closed.

Lets users point SnapAI at any OpenAI-compatible endpoint (Azure OpenAI, OpenRouter, local servers, etc.) instead of `api.openai.com` — requested by multiple users in the #25 comments.

## Why #25 couldn't merge as-is

The original 2-line change failed the build because `ConfigService.get` is typed against `keyof ConfigData`, and `openai_base_url` was never added to that interface:

```
src/services/openai.ts(34,45): error TS2345: Argument of type '"openai_base_url"' is not assignable to parameter of type 'keyof ConfigData'.
```

There was also no way to set the value — the `snapai config` command had no flag for it.

## What this PR adds on top

- `openai_base_url` added to `ConfigData` (fixes the type error)
- `OPENAI_BASE_URL` env var is read with precedence over local config, matching the existing API-key precedence (env > config)
- New `snapai config --openai-base-url <url>` flag with URL validation (http/https only), and the value shown in `snapai config --show`
- README section documenting both the config flag and the env var

When no base URL is configured, `undefined` is passed to the SDK, so existing users see zero behavior change.

## Testing

- `pnpm build` (tsc) and `pnpm lint` pass
- Verified `--openai-base-url` rejects malformed and non-http(s) URLs, persists valid ones, and shows them in `--show`
- End-to-end: ran `snapai icon` against a local fake HTTP server and confirmed the request hit `POST <custom-base>/images/generations` for both the config value and the `OPENAI_BASE_URL` env var, with the env var correctly winning when both were set
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6858-df07-7e29-8475-3c3c122af6f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6858-df07-7e29-8475-3c3c122af6f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

